### PR TITLE
Support newer version of Sphinx

### DIFF
--- a/sphinx_boost/boost/static/boostbook.css
+++ b/sphinx_boost/boost/static/boostbook.css
@@ -824,7 +824,10 @@ Sphinx Styles Adjustments
         padding-left: 0;
     }
 
-    li.toctree-l2
+    li.toctree-l2,
+    li.toctree-l3,
+    li.toctree-l4,
+    li.toctree-l5
     { 
         padding-left: 3em; 
     }
@@ -887,3 +890,22 @@ Sphinx Styles Adjustments
         background-color: #F0F0F0;
         border: 1px solid #DCDCDC;
     }
+
+/* 2022 fix */
+
+ol.simple ol p,
+ol.simple ul p,
+ul.simple ol p,
+ul.simple ul p {
+    margin-top: 0;
+}
+
+ol.simple > li:not(:first-child) > p,
+ul.simple > li:not(:first-child) > p {
+    margin-top: 0;
+}
+
+ol.simple p,
+ul.simple p {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
Continuation of https://github.com/boostorg/hof/pull/222

Newer sphinx versions add a p paragraph tag to all list items.  
This causes the spacing to become too wide. 
The solution is to change the margin css to 0, returning the format back to the way it was originally.   
The new css code is coming from the sphinx project itself. I didn't create it.